### PR TITLE
Change to the middle click action

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -111,8 +111,7 @@ class TaskButton extends PanelMenu.Button {
         if (event.get_button() == Clutter.BUTTON_MIDDLE) {
             this.menu.close();
 
-            if (this._app?.can_open_new_window())
-                this._app?.open_new_window(-1);
+            this._window?.delete(global.get_current_time());
             Main.overview.hide();
 
             return Clutter.EVENT_STOP;


### PR DESCRIPTION
The middle click on the mouse is very useful for quickly closing currently opened windows. I find this shortcut particularly practical for closing tabs on a browser. I think that having this feature on task-up-ultralite would make this gnome extension consistent with the middle click action on browsers, nautilus (and other file explorer) and other gnome extensions.
Here's a short demo :
![Screencast From 2025-06-17 22-36-13](https://github.com/user-attachments/assets/270bf25a-4e88-49ca-8dfd-a1e6f1585533)

This new feature was tested and works well in overview mode
  